### PR TITLE
Add links to binder into example notebooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,8 +94,19 @@ from the `source on GitHub`_.
 
 Requirements
 ============
-The package only requires Sphinx_, ipython and nbconvert to be installed. It
-has been tested for versions higher than 1.3.
+The package requires
+
+- Sphinx_>=1.3: The python library for generating automated documentation
+- jupyter_: The jupyter framework for jupyter notebooks. sphinx-nbexamples
+  explicitly depends on
+
+  - nbconvert_: For converting jupyter notebooks to RST
+  - jupyter_client_: For managing the kernels
+  - ipykernel_: For installing an ipython kernel and run the notebooks
 
 
 .. _Sphinx: http://www.sphinx-doc.org/en/stable
+.. _jupyter: http://jupyter.org/
+.. _nbconvert: https://nbconvert.readthedocs.io
+.. _jupyter_client: https://jupyter-client.readthedocs.io
+.. _ipykernel: https://ipykernel.readthedocs.io

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ example_gallery_config = dict(
     dont_preprocess=['../examples/Subgallery/example_bokeh.ipynb'],
     insert_bokeh='0.12.1',
     urls='https://github.com/Chilipp/sphinx-nbexamples/blob/master/examples',
-    binder_url='https://mybinder.org/v2/gh/Chilipp/sphinx-nbexamples/master',
+    binder_url='https://mybinder.org/v2/gh/Chilipp/sphinx-nbexamples/master?filepath=examples',
     )
 process_examples = not osp.exists(osp.join(osp.dirname(__file__), 'examples'))
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ example_gallery_config = dict(
     dont_preprocess=['../examples/Subgallery/example_bokeh.ipynb'],
     insert_bokeh='0.12.1',
     urls='https://github.com/Chilipp/sphinx-nbexamples/blob/master/examples',
+    binder_url='https://mybinder.org/v2/gh/Chilipp/sphinx-nbexamples/master',
     )
 process_examples = not osp.exists(osp.join(osp.dirname(__file__), 'examples'))
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -130,6 +130,11 @@ here
 
 Including bokeh
 ---------------
+
+.. warn::
+
+    Bokeh is currently not working! See `#10 <https://github.com/Chilipp/sphinx-nbexamples/issues/10>`_
+
 Note that bokeh needs a special treatment, especially when using the scheme
 from readthedocs.org_, because it requires additional style sheets and javascript
 files. So, if you have bokeh plots in your documentation, we recommend to

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -114,16 +114,68 @@ Including a link to the nbviewer
 --------------------------------
 If your notebooks are also published online, you can embed a link to the
 wonderful `jupyter nbviewer`_ in the documentation. You have multiple options
-here
+here. You can either
 
-1. You can either specify the url for each notebook separately providing a
-   mapping from notebook file to url in the ``'urls'`` keyword
-2. Include a url key in the metadata of your notebook
-3. specify one single url in the ``'urls'`` keyword for each example directory
-   from the ``'example_dirs'`` keyword if you have all the example directories
-   available online.
+1. specify the url for each notebook separately providing a mapping from
+   notebook file to url in the ``'urls'`` option of the
+   :confval:`example_gallery_config`
+2. include a url item in the metadata of your notebook that points to
+   the url of the notebook
+3. specify one single url in the ``'urls'`` option of the
+   :confval:`example_gallery_config` that will then be extended to the
+   corresponding notebook path. For sphinx-nbexamples, this looks like::
+
+       example_gallery_config = {
+           urls='https://github.com/Chilipp/sphinx-nbexamples/blob/master/examples',
+       }
 
 .. _jupyter nbviewer: https://nbviewer.jupyter.org
+
+
+.. _binder:
+
+Including a link to the binder
+------------------------------
+`Jupyters binderhub`_ allows to run the example notebooks of your repository
+(see for example mybinder.org_). If your notebooks are also published online,
+sphinx-nbexamples can add a badge like |binder| in the documentation.
+
+You have multiple options here. You can either
+
+1. specify the url for each notebook separately providing a mapping from
+   notebook file to url in the ``'binder_urls'`` option of the
+   :confval:`example_gallery_config`
+2. include a binder_url item in the metadata of your notebook that points to
+   the url of the notebook where it can be run interactively
+3. specify one single url in the ``'binder_urls'`` option of the
+   :confval:`example_gallery_config` that will then be extended to the
+   corresponding notebook path. For sphinx-nbexamples at mybinder.org_, this
+   looks like::
+
+       example_gallery_config = {
+           'binder_url': 'https://mybinder.org/v2/gh/Chilipp/sphinx-nbexamples/master?filepath=examples',
+       }
+
+   or for the `pangeo binder`_::
+
+       example_gallery_config = {
+           'binder_url': 'https://binder.pangeo.io/v2/gh/Chilipp/sphinx-nbexamples/master?filepath=examples',
+       }
+
+   See the binderhub service you use (e.g. mybinder.org_) for how to get this
+   url for your repository. This will, e.g. for the
+   :ref:`example_basic.ipynb <gallery_examples_example_basic.ipynb>` notebook,
+   translate into::
+
+       .. image:: https://mybinder.org/badge_logo.svg
+           :target: https://mybinder.org/v2/gh/Chilipp/sphinx-nbexamples/master?filepath=examples/example_basic.ipynb
+
+.. |binder| image:: https://mybinder.org/badge_logo.svg
+    :target: https://mybinder.org/v2/gh/Chilipp/sphinx-nbexamples/master
+
+.. _jupyters binderhub: https://binderhub.readthedocs.io/en/latest/
+.. _mybinder.org: https://mybinder.org/
+.. _pangeo binder: https://binder.pangeo.io/
 
 
 .. _bokeh:
@@ -131,9 +183,9 @@ here
 Including bokeh
 ---------------
 
-.. warn::
+.. warning::
 
-    Bokeh is currently not working! See `#10 <https://github.com/Chilipp/sphinx-nbexamples/issues/10>`_
+    Bokeh is not working for the latest version (see `#10 <https://github.com/Chilipp/sphinx-nbexamples/issues/10>`_). PR's welcomed!
 
 Note that bokeh needs a special treatment, especially when using the scheme
 from readthedocs.org_, because it requires additional style sheets and javascript

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,11 +108,23 @@ from the `source on GitHub`_.
 
 Requirements
 ============
-The package only requires Sphinx_ to be installed. It has been tested for
-versions higher than 1.3.
+The package requires
+
+- Sphinx_>=1.3: The python library for generating automated documentation
+- jupyter_: The jupyter framework for jupyter notebooks. sphinx-nbexamples
+  explicitly depends on
+
+  - nbconvert_: For converting jupyter notebooks to RST
+  - jupyter_client_: For managing the kernels
+  - ipykernel_: For installing an ipython kernel and run the notebooks
 
 
 .. _Sphinx: http://www.sphinx-doc.org/en/stable
+.. _jupyter: http://jupyter.org/
+.. _nbconvert: https://nbconvert.readthedocs.io
+.. _jupyter_client: https://jupyter-client.readthedocs.io
+.. _ipykernel: https://ipykernel.readthedocs.io
+
 
 
 Indices and tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
 matplotlib
 bokeh
 seaborn
-ipython
-nbconvert
-sphinx
-jupyter_client
-ipykernel
 bash_kernel

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(name='sphinx-nbexamples',
       ],
       keywords=('sphinx sphinx-gallery examples documentation notebook ipython'
                 ' jupyter nbconvert nbsphinx'),
+      project_urls={
+          'Documentation': 'https://sphinx-nbexamples.readthedocs.io',
+      },
       url='https://github.com/Chilipp/sphinx-nbexamples',
       author='Philipp Sommer',
       author_email='philipp.sommer@unil.ch',

--- a/sphinx_nbexamples/__init__.py
+++ b/sphinx_nbexamples/__init__.py
@@ -349,22 +349,25 @@ class NotebookProcessor(object):
         ext = language_info.get('file_extension', 'py')
         self.script = self.get_out_file(ext.lstrip('.'))
 
-        # disable warnings in the rst file
         disable_warnings = disable_warnings and self.script.endswith('.py')
-        if disable_warnings:
-            for i, cell in enumerate(nb.cells):
-                if cell['cell_type'] == 'code':
-                    cell = cell.copy()
-                    break
-            cell = cell.copy()
-            cell.source = """
+
+        # write and process rst_file
+        if self.preprocess:
+
+            # disable warnings in the rst file
+            if disable_warnings:
+                for i, cell in enumerate(nb.cells):
+                    if cell['cell_type'] == 'code':
+                        cell = cell.copy()
+                        break
+                cell = cell.copy()
+                cell.source = """
 import logging
 logging.captureWarnings(True)
 logging.getLogger('py.warnings').setLevel(logging.ERROR)
 """
-            nb.cells.insert(i, cell)
-        # write and process rst_file
-        if self.preprocess:
+                nb.cells.insert(i, cell)
+
             t = dt.datetime.now()
             logger.info('Processing %s', self.infile)
             try:


### PR DESCRIPTION
Closes https://github.com/Chilipp/sphinx-nbexamples/issues/2

This PR 

- adds the possibility to include badges like [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Chilipp/sphinx-nbexamples/master) in the documentation that point to the specific notebook in binder
- includes a warning for bokeh in the docs (see https://github.com/Chilipp/sphinx-nbexamples/issues/10)